### PR TITLE
feat: auto-populate nuclides from materials.xml when omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ See `example/simple_tokamak` for example
 
 1. Configure the `uq_inputs.json` input script
 
-2. Run it! `julia MonteCarlo.jl uq_inputs.json`
+2. Setup nuclides and covariance filtering: `python3 setup.py uq_inputs.json`
+
+3. Run it! `julia MonteCarlo.jl uq_inputs.json`
 - Or submit `julia MonteCarlo.jl uq_inputs.json` in a slurm script with a few cpus
 
 Things to consider while configuring the input file:
@@ -46,6 +48,7 @@ Things to consider while configuring the input file:
 - `solver_inputs["nuclides"]` is optional:
   - If omitted, set to `null`, or set to `[]`, nuclides are auto-loaded from `openmc_xml_dir/materials.xml`
   - If provided as a non-empty list, only the listed nuclides are sampled
+  - `setup.py` filters this list to nuclides with both an ENDF file and MF33 covariance data, then writes the filtered list back to `uq_inputs.json`
 - Modify the HPC credentials
    - You can optionally change the `throttle` (max samples run simultaneous)
    - You can optionally change `ntasks` (5 cores gives a simulation time ~2 mins per simulation)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Things to consider while configuring the input file:
 - Modify your `endf_dir`
 - Modify your openmc cross_sections.xml (ideally the same library as whatever ENDF library you've specified)
 - Modify the `openmc_xml_dir`, should point to the directory containing your OpenMC input files
+- `solver_inputs["nuclides"]` is optional:
+  - If omitted, set to `null`, or set to `[]`, nuclides are auto-loaded from `openmc_xml_dir/materials.xml`
+  - If provided as a non-empty list, only the listed nuclides are sampled
 - Modify the HPC credentials
    - You can optionally change the `throttle` (max samples run simultaneous)
    - You can optionally change `ntasks` (5 cores gives a simulation time ~2 mins per simulation)
@@ -75,7 +78,9 @@ Other variance reduction, such as Subset Simulation are available, for evaluatin
 
 ### What does `setup.py` do? 
 
-It performs an SVD of all the covariances available within your specified ENDF library, stores the matrices, and computes the number of components to capture 99% of the variance of each nuclide. 
+It performs an SVD of all the covariances available within your specified ENDF library, stores the matrices, and computes the number of components to capture 99% of the variance of each nuclide.
+If `solver_inputs["nuclides"]` is omitted, `null`, or `[]`, `setup.py` auto-loads nuclides from `openmc_xml_dir/materials.xml`.
+`setup.py` then filters out nuclides with missing ENDF/covariance data and writes both the filtered `solver_inputs["nuclides"]` and `solver_inputs["dimensions"]["dims"]` back to `uq_inputs.json`.
 
 For most nuclides it is quite expensive to compute SVDs, so parallelism is also provided. In a slurm script:
 

--- a/example/simple_tokamak/MonteCarlo.jl
+++ b/example/simple_tokamak/MonteCarlo.jl
@@ -75,10 +75,25 @@ function resolve_nuclides!(solver_inputs::Dict{String,Any})
     return nuclides
 end
 
+function should_autoload_nuclides(solver_inputs::Dict{String,Any})
+    return !haskey(solver_inputs, "nuclides") ||
+           solver_inputs["nuclides"] === nothing ||
+           (solver_inputs["nuclides"] isa AbstractVector && isempty(solver_inputs["nuclides"]))
+end
+
 # Set local variables
 solver_exe               = inputs["solver_exe"]
-solver_inputs            = Dict(inputs["solver_inputs"])
+raw_solver_inputs        = Dict(inputs["solver_inputs"])
+autoload_nuclides        = should_autoload_nuclides(raw_solver_inputs)
+solver_inputs            = Dict(raw_solver_inputs)
 resolved_nuclides        = resolve_nuclides!(solver_inputs)
+if autoload_nuclides
+    inputs["solver_inputs"]["nuclides"] = resolved_nuclides
+    open(input_file, "w") do f
+        JSON.print(f, inputs, 4)
+    end
+    println("Persisted $(length(resolved_nuclides)) sampled nuclides to '$input_file'.")
+end
 solver_config            = inputs["solver_config"]
 reliability_qoi_name     = inputs["reliability_qoi_name"]
 reliability_qoi_criteria = inputs["reliability_qoi_criteria"]

--- a/example/simple_tokamak/MonteCarlo.jl
+++ b/example/simple_tokamak/MonteCarlo.jl
@@ -22,78 +22,9 @@ end
 println("Reading inputs from: ", input_file)
 inputs = JSON.parsefile(input_file)
 
-function parse_nuclides_from_materials_xml(materials_xml_path::String)
-    if !isfile(materials_xml_path)
-        error("Cannot auto-populate nuclides: '$materials_xml_path' was not found.")
-    end
-
-    pattern = r"<nuclide\b[^>]*\bname=['\"]([^'\"]+)['\"]"
-    nuclides = String[]
-    for line in eachline(materials_xml_path)
-        for m in eachmatch(pattern, line)
-            push!(nuclides, m.captures[1])
-        end
-    end
-
-    nuclides = unique(nuclides)
-    if isempty(nuclides)
-        error("Cannot auto-populate nuclides: no '<nuclide ... name=\"...\"/>' entries were found in '$materials_xml_path'.")
-    end
-
-    return nuclides
-end
-
-function resolve_nuclides!(solver_inputs::Dict{String,Any})
-    if !haskey(solver_inputs, "nuclides") ||
-       solver_inputs["nuclides"] === nothing ||
-       (solver_inputs["nuclides"] isa AbstractVector && isempty(solver_inputs["nuclides"]))
-        if !haskey(solver_inputs, "openmc_xml_dir")
-            error("Cannot auto-populate nuclides: `openmc_xml_dir` is missing from solver inputs.")
-        end
-        materials_xml = joinpath(String(solver_inputs["openmc_xml_dir"]), "materials.xml")
-        nuclides = parse_nuclides_from_materials_xml(materials_xml)
-        solver_inputs["nuclides"] = nuclides
-        println("No nuclides were specified. Loaded $(length(nuclides)) nuclides from '$materials_xml'.")
-        return nuclides
-    end
-
-    raw_nuclides = solver_inputs["nuclides"]
-    if !(raw_nuclides isa AbstractVector)
-        error("Invalid `nuclides` input: expected an array, null, or missing key.")
-    end
-
-    nuclides = String[]
-    for (i, nuclide) in enumerate(raw_nuclides)
-        nuclide_str = strip(string(nuclide))
-        if isempty(nuclide_str)
-            error("Invalid nuclide at index $i: expected a non-empty string.")
-        end
-        push!(nuclides, nuclide_str)
-    end
-
-    solver_inputs["nuclides"] = nuclides
-    return nuclides
-end
-
-function should_autoload_nuclides(solver_inputs::Dict{String,Any})
-    return !haskey(solver_inputs, "nuclides") ||
-           solver_inputs["nuclides"] === nothing ||
-           (solver_inputs["nuclides"] isa AbstractVector && isempty(solver_inputs["nuclides"]))
-end
-
 # Set local variables
 solver_exe               = inputs["solver_exe"]
-raw_solver_inputs        = Dict(inputs["solver_inputs"])
-autoload_nuclides        = should_autoload_nuclides(raw_solver_inputs)
-solver_inputs            = Dict(raw_solver_inputs)
-resolved_nuclides        = resolve_nuclides!(solver_inputs)
-if autoload_nuclides
-    inputs["solver_inputs"]["nuclides"] = resolved_nuclides
-    open(input_file, "w") do f
-        JSON.print(f, inputs, 4)
-    end
-    println("Persisted $(length(resolved_nuclides)) sampled nuclides to '$input_file'.")
-end
+solver_inputs            = Dict(inputs["solver_inputs"])
 solver_config            = inputs["solver_config"]
 reliability_qoi_name     = inputs["reliability_qoi_name"]
 reliability_qoi_criteria = inputs["reliability_qoi_criteria"]
@@ -193,7 +124,7 @@ sampling = MonteCarlo(num_samples)
 ############################################################################
 # Define random variables corresponding to seeds for each nuclide.
 INT64MAX=typemax(Int64)
-nuclides=resolved_nuclides
+nuclides=solver_inputs["nuclides"]
 num_seeds=length(nuclides)
 random_variable_list=Vector{RandomVariable}()
 seed_string_list=Vector{String}()

--- a/example/simple_tokamak/MonteCarlo.jl
+++ b/example/simple_tokamak/MonteCarlo.jl
@@ -22,9 +22,63 @@ end
 println("Reading inputs from: ", input_file)
 inputs = JSON.parsefile(input_file)
 
+function parse_nuclides_from_materials_xml(materials_xml_path::String)
+    if !isfile(materials_xml_path)
+        error("Cannot auto-populate nuclides: '$materials_xml_path' was not found.")
+    end
+
+    pattern = r"<nuclide\b[^>]*\bname=['\"]([^'\"]+)['\"]"
+    nuclides = String[]
+    for line in eachline(materials_xml_path)
+        for m in eachmatch(pattern, line)
+            push!(nuclides, m.captures[1])
+        end
+    end
+
+    nuclides = unique(nuclides)
+    if isempty(nuclides)
+        error("Cannot auto-populate nuclides: no '<nuclide ... name=\"...\"/>' entries were found in '$materials_xml_path'.")
+    end
+
+    return nuclides
+end
+
+function resolve_nuclides!(solver_inputs::Dict{String,Any})
+    if !haskey(solver_inputs, "nuclides") ||
+       solver_inputs["nuclides"] === nothing ||
+       (solver_inputs["nuclides"] isa AbstractVector && isempty(solver_inputs["nuclides"]))
+        if !haskey(solver_inputs, "openmc_xml_dir")
+            error("Cannot auto-populate nuclides: `openmc_xml_dir` is missing from solver inputs.")
+        end
+        materials_xml = joinpath(String(solver_inputs["openmc_xml_dir"]), "materials.xml")
+        nuclides = parse_nuclides_from_materials_xml(materials_xml)
+        solver_inputs["nuclides"] = nuclides
+        println("No nuclides were specified. Loaded $(length(nuclides)) nuclides from '$materials_xml'.")
+        return nuclides
+    end
+
+    raw_nuclides = solver_inputs["nuclides"]
+    if !(raw_nuclides isa AbstractVector)
+        error("Invalid `nuclides` input: expected an array, null, or missing key.")
+    end
+
+    nuclides = String[]
+    for (i, nuclide) in enumerate(raw_nuclides)
+        nuclide_str = strip(string(nuclide))
+        if isempty(nuclide_str)
+            error("Invalid nuclide at index $i: expected a non-empty string.")
+        end
+        push!(nuclides, nuclide_str)
+    end
+
+    solver_inputs["nuclides"] = nuclides
+    return nuclides
+end
+
 # Set local variables
 solver_exe               = inputs["solver_exe"]
 solver_inputs            = Dict(inputs["solver_inputs"])
+resolved_nuclides        = resolve_nuclides!(solver_inputs)
 solver_config            = inputs["solver_config"]
 reliability_qoi_name     = inputs["reliability_qoi_name"]
 reliability_qoi_criteria = inputs["reliability_qoi_criteria"]
@@ -124,7 +178,7 @@ sampling = MonteCarlo(num_samples)
 ############################################################################
 # Define random variables corresponding to seeds for each nuclide.
 INT64MAX=typemax(Int64)
-nuclides=solver_inputs["nuclides"]
+nuclides=resolved_nuclides
 num_seeds=length(nuclides)
 random_variable_list=Vector{RandomVariable}()
 seed_string_list=Vector{String}()

--- a/example/simple_tokamak/run_model.py
+++ b/example/simple_tokamak/run_model.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sys
 import openmc
 import openmc_uq
+from openmc_uq.utils import resolve_nuclides
 
 parser = argparse.ArgumentParser()
 parser.add_argument("input_file")
@@ -18,17 +19,22 @@ inputs_dict={}
 with open(args.input_file) as handle:
     inputs_dict = json.load(handle)
 
+# Directory of openmc model.
+openmc_xml_dir = inputs_dict["openmc_xml_dir"]
+
+# Nuclides to sample (explicit list or fallback from materials.xml)
+nuclides = resolve_nuclides(inputs_dict.get("nuclides"), openmc_xml_dir)
+
 # Random seeds (one for each nuclide)
 seeds = inputs_dict["seeds"]
-
-# Nuclides to sample
-nuclides = inputs_dict["nuclides"]
+if len(seeds) != len(nuclides):
+    raise ValueError(
+        f"Length mismatch: got {len(seeds)} seeds for {len(nuclides)} nuclides. "
+        "Ensure seeds and nuclides have identical lengths."
+    )
 
 # ENDF directory. Used to generate random data.
 endf_path = inputs_dict["endf_dir"]
-
-# Directory of openmc model.
-openmc_xml_dir = inputs_dict["openmc_xml_dir"]
 
 # Local directory name to run in
 run_dir = inputs_dict["run_dir"]

--- a/example/simple_tokamak/setup.py
+++ b/example/simple_tokamak/setup.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+import argparse
+import json
+import numpy as np
+
+from openmc_uq.utils import (
+    check_covariance,
+    get_nuclide_paths,
+    resolve_nuclides,
+)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("input_file")
+args = parser.parse_args()
+
+print("Configuring from: ", args.input_file)
+inputs_dict = {}
+with open(args.input_file) as handle:
+    inputs_dict = json.load(handle)
+
+solver_inputs = inputs_dict["solver_inputs"]
+nuclides = resolve_nuclides(
+    solver_inputs.get("nuclides"),
+    solver_inputs["openmc_xml_dir"],
+)
+nuclides = np.array(nuclides)
+n_requested = len(nuclides)
+
+endf_folder = solver_inputs["endf_dir"]
+paths = np.array(get_nuclide_paths(endf_folder, nuclides))
+
+is_not_empty = np.array([p != "" for p in paths], dtype=bool)
+nuclides = nuclides[is_not_empty]
+paths = paths[is_not_empty]
+
+have_covs = np.array([check_covariance(path) for path in paths], dtype=bool)
+nuclides = nuclides[have_covs]
+
+if len(nuclides) == 0:
+    raise RuntimeError(
+        "No nuclides remain after filtering for available ENDF files and covariance data."
+    )
+
+if len(nuclides) < n_requested:
+    print(
+        f"Filtered out {n_requested - len(nuclides)} nuclides due to missing ENDF files/covariance data."
+    )
+
+inputs_dict["solver_inputs"]["nuclides"] = nuclides.tolist()
+
+print(
+    f"Writing updated solver_inputs with {len(nuclides)} filtered nuclides "
+    f"to '{args.input_file}'."
+)
+
+with open(args.input_file, "w") as handle:
+    json.dump(inputs_dict, handle, indent=4)

--- a/example/simple_tokamak_advanced/run_model.py
+++ b/example/simple_tokamak_advanced/run_model.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import openmc
 import openmc_uq
+from openmc_uq.utils import resolve_nuclides
 
 parser = argparse.ArgumentParser()
 parser.add_argument("input_file")
@@ -20,15 +21,15 @@ inputs_dict={}
 with open(args.input_file) as handle:
     inputs_dict = json.load(handle)
 
-# Nuclides to sample
-nuclides = inputs_dict["nuclides"]
+# Directory of openmc model.
+openmc_xml_dir = inputs_dict["openmc_xml_dir"]
+
+# Nuclides to sample (explicit list or fallback from materials.xml)
+nuclides = resolve_nuclides(inputs_dict.get("nuclides"), openmc_xml_dir)
 
 # ENDF directory. Used to generate random data.
 endf_path = inputs_dict["endf_dir"]
 pre_processed_dir = inputs_dict["pre_processed_dir"]
-
-# Directory of openmc model.
-openmc_xml_dir = inputs_dict["openmc_xml_dir"]
 
 # Local directory name to run in
 run_dir = inputs_dict["run_dir"]
@@ -52,6 +53,12 @@ with open(sample_file, "r") as f:
 
 # Number of dimensions for each nuclide
 dims = np.array(inputs_dict["dimensions"]["dims"])
+if len(dims) != len(nuclides):
+    raise ValueError(
+        f"Length mismatch: got {len(dims)} dimensions for {len(nuclides)} nuclides. "
+        "Run setup.py and ensure `nuclides` and `dimensions` are aligned."
+    )
+
 dim_cum = np.cumsum(dims)
 dim_cum = np.insert(dim_cum, 0, 0)
 

--- a/example/simple_tokamak_advanced/setup.py
+++ b/example/simple_tokamak_advanced/setup.py
@@ -6,7 +6,12 @@ import numpy as np
 
 from multiprocessing import Pool
 
-from openmc_uq.utils import get_nuclide_paths, check_covariance, svd_and_save_error
+from openmc_uq.utils import (
+    get_nuclide_paths,
+    check_covariance,
+    svd_and_save_error,
+    resolve_nuclides,
+)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("input_file")
@@ -17,12 +22,17 @@ inputs_dict={}
 with open(args.input_file) as handle:
     inputs_dict = json.load(handle)
 
-nuclides =  inputs_dict["solver_inputs"]["nuclides"]
+solver_inputs = inputs_dict["solver_inputs"]
+nuclides = resolve_nuclides(
+    solver_inputs.get("nuclides"),
+    solver_inputs["openmc_xml_dir"],
+)
 
 nuclides = np.array(nuclides)
 
-endf_folder = inputs_dict["solver_inputs"]["endf_dir"]
-save_folder = inputs_dict["solver_inputs"]["pre_processed_dir"]
+endf_folder = solver_inputs["endf_dir"]
+save_folder = solver_inputs["pre_processed_dir"]
+n_requested = len(nuclides)
 
 paths = get_nuclide_paths(endf_folder, nuclides)
 paths = np.array(paths)
@@ -36,7 +46,17 @@ have_covs = [check_covariance(file) for file in paths]
 nuclides = nuclides[have_covs]
 paths = paths[have_covs]
 
-N_workers = int(os.getenv('SLURM_NTASKS'))
+if len(nuclides) == 0:
+    raise RuntimeError(
+        "No nuclides remain after filtering for available ENDF files and covariance data."
+    )
+
+if len(nuclides) < n_requested:
+    print(
+        f"Filtered out {n_requested - len(nuclides)} nuclides due to missing ENDF files/covariance data."
+    )
+
+N_workers = int(os.getenv("SLURM_NTASKS", "1"))
 print(f"Performing svd with N_workers={N_workers}")
 
 print("Beginning NJOY processing")
@@ -60,13 +80,10 @@ reduced_dims, full_dims = map(list, zip(*results))
 print()
 print()
 print("---------------------------------------------------------------------")
-print(f"Nuclides {nuclides} have been sucessfully processed and have the following reduced dimensions")
+print(f"Nuclides {nuclides} have been successfully processed and have the following reduced dimensions")
 print(f"reduced_dims: {reduced_dims}")
 print(f"full_dims: {full_dims}")
 print("---------------------------------------------------------------------")
-print()
-print()
-print("########## TODO ADD ADDITIONAL WARNING THAT SOME NUCLIDES MAY HAVE BEEN REMOVED FROM THE LIST IF NO COVARIANCE FOUND ############")
 print()
 print()
 
@@ -82,9 +99,15 @@ if inputs_dict["dimension_reduction"]:
 else:
     nuclide_dim_sim = full_dims
 
+inputs_dict["solver_inputs"]["nuclides"] = nuclides.tolist()
 inputs_dict["solver_inputs"]["dimensions"] = {
     "dims": nuclide_dim_sim,
     }
+
+print(
+    f"Writing updated solver_inputs with {len(nuclides)} nuclides "
+    f"and {len(nuclide_dim_sim)} dimensions."
+)
 
 # Save back to file
 with open(args.input_file, "w") as f:

--- a/openmc_uq/utils.py
+++ b/openmc_uq/utils.py
@@ -8,6 +8,81 @@ from sandy import Endf6
 import openmc.data.reaction
 from pathlib import Path
 from scipy.linalg import svd
+import xml.etree.ElementTree as ET
+
+
+def _unique_preserve_order(values: list[str]) -> list[str]:
+    """Return unique values in first-seen order."""
+    unique = []
+    seen = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        unique.append(value)
+    return unique
+
+
+def get_nuclides_from_materials_xml(materials_xml: str | Path) -> list[str]:
+    """
+    Parse `materials.xml` and return unique nuclide names in first-seen order.
+    """
+    materials_xml = Path(materials_xml).resolve()
+    if not materials_xml.is_file():
+        raise FileNotFoundError(
+            f"Cannot auto-populate nuclides: '{materials_xml}' was not found."
+        )
+
+    try:
+        root = ET.parse(materials_xml).getroot()
+    except ET.ParseError as exc:
+        raise ValueError(f"Failed to parse '{materials_xml}': {exc}") from exc
+
+    nuclides = []
+    for nuclide in root.findall(".//nuclide"):
+        name = nuclide.get("name")
+        if name:
+            nuclides.append(name)
+
+    nuclides = _unique_preserve_order(nuclides)
+    if len(nuclides) == 0:
+        raise ValueError(
+            f"Cannot auto-populate nuclides: no '<nuclide ... name=\"...\"/>' entries "
+            f"were found in '{materials_xml}'."
+        )
+
+    return nuclides
+
+
+def resolve_nuclides(nuclides, openmc_xml_dir: str | Path) -> list[str]:
+    """
+    Resolve nuclides from explicit input or fallback to openmc_xml_dir/materials.xml.
+
+    Fallback is triggered when `nuclides` is missing/null/empty list.
+    """
+    if nuclides is None or (isinstance(nuclides, list) and len(nuclides) == 0):
+        materials_xml = Path(openmc_xml_dir).resolve() / "materials.xml"
+        resolved = get_nuclides_from_materials_xml(materials_xml)
+        print(
+            f"No nuclides were specified. Loaded {len(resolved)} nuclides from "
+            f"'{materials_xml}'."
+        )
+        return resolved
+
+    if not isinstance(nuclides, list):
+        raise TypeError(
+            "Invalid `nuclides` input: expected a list, null, or missing key."
+        )
+
+    resolved = []
+    for i, nuclide in enumerate(nuclides):
+        if not isinstance(nuclide, str) or len(nuclide.strip()) == 0:
+            raise ValueError(
+                f"Invalid nuclide at index {i}: expected a non-empty string, got {nuclide!r}."
+            )
+        resolved.append(nuclide)
+
+    return resolved
 
 def get_nuclide_paths(endf_path: str, nuclides: list[str]) -> list[str]:
     """


### PR DESCRIPTION
This is WIP, I haven't checked it works yet.

## Overview
This change makes `solver_inputs.nuclides` optional.

If `nuclides` is missing, `null`, or `[]`, the workflow now reads
`openmc_xml_dir/materials.xml` and auto-populates nuclides from all
`<nuclide ... name="...">` entries (deduplicated in first-seen order).

If `nuclides` is explicitly provided, only those nuclides are sampled.

## Implemented Changes
- Added shared helper functions in `openmc_uq/utils.py`:
  - `get_nuclides_from_materials_xml(materials_xml)`
  - `resolve_nuclides(nuclides, openmc_xml_dir)`
- Updated `example/simple_tokamak/MonteCarlo.jl`:
  - Resolve/fill `solver_inputs["nuclides"]` before seed generation.
- Updated `example/simple_tokamak/run_model.py`:
  - Use shared resolver.
  - Validate `len(seeds) == len(nuclides)`.
- Updated `example/simple_tokamak_advanced/setup.py`:
  - Use shared resolver before ENDF covariance filtering.
  - Write back filtered `solver_inputs["nuclides"]` and aligned `solver_inputs["dimensions"]["dims"]`.
  - Added clear error when no nuclides remain after filtering.
- Updated `example/simple_tokamak_advanced/run_model.py`:
  - Use shared resolver.
  - Validate `len(dimensions["dims"]) == len(nuclides)`.
- Updated documentation in `README.md`.

## Behavior Changes
- `solver_inputs.nuclides` now supports:
  - missing key
  - `null`
  - empty list `[]`
- Fallback source is strictly `openmc_xml_dir/materials.xml`.
- Advanced `setup.py` now persists filtered nuclides alongside computed dimensions to prevent mismatch errors downstream.

## Validation Limitations
- I haven't tested this yet.
- I haven't checked Julia syntax.